### PR TITLE
Update packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.6.7-slim
 
-
 WORKDIR /src
 
 COPY . /src
+
+RUN pip install --upgrade pip
 
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy==1.15.2
+numpy==1.14.5
 flask==1.0.2
 python-dotenv==0.9.1
 keras==2.2.4
-tensorflow
+tensorflow==1.10.1
 flask-cors==3.0.6
 Pillow==5.3.0
 imageio==2.4.1
-scipy==0.19.1
+scipy==1.1.0


### PR DESCRIPTION
Got this error and then new tensorflow was not compatible with numpy and scipy so I updated them.
I have not used tensoflow before but his setup worked for me.

```
Collecting grpcio>=1.8.6 (from tensorflow==1.10.1->-r requirements.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/cf/7a/9744998129fce7e29c5f2d8b0f545913b7383e65d8366fc0ae98d11936af/grpcio-1.28.1.tar.gz (19.5MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-obnl3web/grpcio/setup.py", line 191, in <module>
        if check_linker_need_libatomic():
      File "/tmp/pip-install-obnl3web/grpcio/setup.py", line 152, in check_linker_need_libatomic
        stderr=PIPE)
      File "/usr/local/lib/python3.6/subprocess.py", line 709, in __init__
        restore_signals, start_new_session)
      File "/usr/local/lib/python3.6/subprocess.py", line 1344, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'cc': 'cc'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-obnl3web/grpcio/
You are using pip version 18.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
ERROR: Service 'backend' failed to build: The command '/bin/sh -c pip install --trusted-host pypi.python.org -r requirements.txt' returned a non-zero code: 1
```